### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Deploying to GitHub Pages
+
+Este projeto usa [Vite](https://vitejs.dev/) com React e pode ser hospedado de maneira gratuita no GitHub Pages. Um workflow de GitHub Actions foi adicionado para automatizar o processo de build e deploy.
+
+## Passos para publicar
+
+1. Certifique-se de que o repositório está hospedado no GitHub.
+2. Altere, se necessário, o nome do repositório utilizado no caminho base editando `vite.config.ts`.
+3. Habilite o GitHub Pages nas configurações do repositório, escolhendo a opção "GitHub Actions" como origem.
+4. Ao realizar um push para o branch `main`, o workflow `Deploy to GitHub Pages` será executado e publicá o conteúdo da pasta `dist`.
+
+Após a execução do workflow, seu site estará disponível em `https://<usuario>.github.io/<nome-do-repositorio>/`.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,19 +4,23 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-    server: {
-        host: "::",
-        port: 8080,
-    },
-    plugins: [
-        react(),
-        mode === 'development' &&
-        componentTagger(),
-    ].filter(Boolean),
-    resolve: {
-        alias: {
-            "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+    const repoName = process.env.GITHUB_REPOSITORY?.split("/")[1];
+    return {
+        base: mode === "development" ? "/" : repoName ? `/${repoName}/` : "/",
+        server: {
+            host: "::",
+            port: 8080,
         },
-    },
-}));
+        plugins: [
+            react(),
+            mode === 'development' &&
+            componentTagger(),
+        ].filter(Boolean),
+        resolve: {
+            alias: {
+                "@": path.resolve(__dirname, "./src"),
+            },
+        },
+    };
+});


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for GitHub Pages
- support `base` path for Pages build
- document deployment steps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688545f81d58832187fec7ef04199458